### PR TITLE
Fix package name for composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Provides a _table_ as attribute type where you can define a set of columns of di
 Simply install the package with the following command: 
 
 ``` bash
-composer require flagbit/reference-entity-table-bundle
+composer require flagbit/akeneo-reference-entity-table-bundle
 ```
 
 ### Enable the bundle


### PR DESCRIPTION
This uses the correct name for the package.

It is defined as `flagbit/akeneo-reference-entity-table-bundle` in https://github.com/flagbit/akeneo-reference-entity-table-bundle/blob/master/composer.json#L2