### PR TITLE
Fix of empty labels editing in localized select

### DIFF
--- a/src/Resources/public/reference-entity/attribute/table/type/localized-select.tsx
+++ b/src/Resources/public/reference-entity/attribute/table/type/localized-select.tsx
@@ -117,7 +117,8 @@ export default class LocalizedSelect implements Type {
                                                 className={'AknTextField AknTextField--light'}
                                                 onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
                                                     const localeCode: string = locale.code;
-                                                    let optionValues = option.values;
+                                                    // Can only be array when it's empty. This depends on the JSON decode in PHP
+                                                    const optionValues = Array.isArray(option.values) ? {} : option.values;
                                                     optionValues[localeCode] = event.target.value;
                                                     config.options[index] = { code: option.code, values: optionValues };
                                                     config.options = cleanOptions(config.options);


### PR DESCRIPTION
When a code was added but the labels were left empty for an option and the attribute was saved that way, a user was unable to edit these labels afterwards.

Because a fix on PHP side would involve overriding one or more Akeneo classes, that need to maintained in this project, I decided to put the fix in the localized-select itself.

___

[FLAGRETAB-13](https://jira.flagbit.cloud/browse/FLAGRETAB-13)