### PR TITLE
Introduce single_reference_entity type

### DIFF
--- a/.github/workflows/frontend-analysis.yml
+++ b/.github/workflows/frontend-analysis.yml
@@ -41,7 +41,7 @@ jobs:
         run: "yarn ts-unused-exports tsconfig.json $(find src/Resources/public -name '*.ts*') --showLineNumber"
 
       - name: "Typescript linting"
-        run: "yarn tslint src/Resources/public/**/*.ts src/Resources/public/**/*.tsx"
+        run: "yarn tslint src/Resources/public/**/*.ts src/Resources/public/**/*.tsx src/Resources/public/**/**/*.tsx"
 
       - name: "Coding Style"
         run: "yarn prettier --config .prettierrc.json --check src/Resources/public/**/*.ts src/Resources/public/**/*.tsx jest/**/*.ts jest/**/*.tsx"

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,8 @@ module.exports = {
     transform: {
         "^.+\\.(ts|tsx)$": "ts-jest"
     },
-    setupFiles: [`<rootDir>/vendor/akeneo/pim-community-dev/tests/front/unit/jest/enzyme.js`],
+    setupFiles: [
+        `<rootDir>/vendor/akeneo/pim-community-dev/tests/front/unit/jest/enzyme.js`,
+        `<rootDir>/jest/mock-fix.ts`
+    ],
 };

--- a/jest/mock-fix.ts
+++ b/jest/mock-fix.ts
@@ -1,0 +1,1 @@
+jest.mock('pim/user-context', () => {});

--- a/jest/public/reference-entity/attribute/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/reference-entity.ts
+++ b/jest/public/reference-entity/attribute/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/reference-entity.ts
@@ -1,0 +1,36 @@
+import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/reference-entity/list';
+// import ReferenceEntityListItem, {
+//     denormalizeReferenceEntityListItem,
+//     NormalizedReferenceEntityListItem
+// } from "akeneoreferenceentity/domain/model/reference-entity/list";
+// import Identifier
+//     from "akeneoreferenceentity/domain/model/identifier";
+// import File
+//     from "akeneoreferenceentity/domain/model/file";
+
+class ReferenceEntityListItemImpl {
+    // Identifier
+    getIdentifier(): any {}
+
+    getLabel(locale: string, fallbackOnCode?: boolean): string {
+        return 'label';
+    }
+
+    // File
+    getImage(): any {}
+
+    equals(referenceEntityListItem: ReferenceEntityListItem): boolean {
+        return true;
+    }
+
+    // NormalizedReferenceEntityListItem
+    normalize(): any {}
+}
+
+class Foo {
+    async fetchAll(): Promise<ReferenceEntityListItem[]> {
+        return [new ReferenceEntityListItemImpl(), new ReferenceEntityListItemImpl()];
+    }
+}
+
+export default new Foo();

--- a/jest/public/reference-entity/attribute/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/reference-entity.ts
+++ b/jest/public/reference-entity/attribute/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/reference-entity.ts
@@ -1,4 +1,5 @@
 import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/reference-entity/list';
+import Identifier from 'akeneoreferenceentity/domain/model/reference-entity/identifier';
 // import ReferenceEntityListItem, {
 //     denormalizeReferenceEntityListItem,
 //     NormalizedReferenceEntityListItem
@@ -9,11 +10,14 @@ import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/referenc
 //     from "akeneoreferenceentity/domain/model/file";
 
 class ReferenceEntityListItemImpl {
-    // Identifier
-    getIdentifier(): any {}
+    constructor(readonly code: string, readonly labels: object) {}
+
+    getIdentifier(): Identifier {
+        return Identifier.create(this.code);
+    }
 
     getLabel(locale: string, fallbackOnCode?: boolean): string {
-        return 'label';
+        return this.labels[locale];
     }
 
     // File
@@ -27,10 +31,13 @@ class ReferenceEntityListItemImpl {
     normalize(): any {}
 }
 
-class Foo {
+class referenceEntityFetcher {
     async fetchAll(): Promise<ReferenceEntityListItem[]> {
-        return [new ReferenceEntityListItemImpl(), new ReferenceEntityListItemImpl()];
+        return [
+            new ReferenceEntityListItemImpl('code1', { de_DE: 'label1', en_US: 'label11' }),
+            new ReferenceEntityListItemImpl('code2', { de_DE: 'label2', en_US: 'label22' }),
+        ];
     }
 }
 
-export default new Foo();
+export default new referenceEntityFetcher();

--- a/jest/public/reference-entity/attribute/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/reference-entity.ts
+++ b/jest/public/reference-entity/attribute/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/reference-entity.ts
@@ -1,13 +1,5 @@
 import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/reference-entity/list';
 import Identifier from 'akeneoreferenceentity/domain/model/reference-entity/identifier';
-// import ReferenceEntityListItem, {
-//     denormalizeReferenceEntityListItem,
-//     NormalizedReferenceEntityListItem
-// } from "akeneoreferenceentity/domain/model/reference-entity/list";
-// import Identifier
-//     from "akeneoreferenceentity/domain/model/identifier";
-// import File
-//     from "akeneoreferenceentity/domain/model/file";
 
 class ReferenceEntityListItemImpl {
     constructor(readonly code: string, readonly labels: object) {}
@@ -20,14 +12,12 @@ class ReferenceEntityListItemImpl {
         return this.labels[locale];
     }
 
-    // File
     getImage(): any {}
 
     equals(referenceEntityListItem: ReferenceEntityListItem): boolean {
         return true;
     }
 
-    // NormalizedReferenceEntityListItem
     normalize(): any {}
 }
 

--- a/jest/public/reference-entity/attribute/table/type/localized-select.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/localized-select.test.tsx
@@ -1,4 +1,6 @@
-import { SelectConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/localized-select';
+import LocalizedSelect, {
+    SelectConfig,
+} from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/localized-select';
 import Locale, { ConcreteLocale } from 'akeneoreferenceentity/domain/model/locale';
 import renderType from './test-helper';
 import * as React from 'react';
@@ -9,7 +11,7 @@ describe('Localized Simple Select type', function () {
     test('Default rendering', function () {
         const onchange = jest.fn();
 
-        const renderedRecordType = renderType({} as SelectConfig, 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType({} as SelectConfig, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         expect(onchange.mock.calls.length).toBe(1);
         expect(onchange.mock.calls[0][0]).toStrictEqual({ options: [] });
@@ -33,7 +35,7 @@ describe('Localized Simple Select type', function () {
     });
 
     test('Render options', function () {
-        const renderedRecordType = renderType(getOptions(), 'simple_select_localized', jest.fn(), createLocales());
+        const renderedRecordType = renderType(getOptions(), new LocalizedSelect('simple_select_localized'), jest.fn(), createLocales());
 
         const tr = renderedRecordType.find('tbody').find('tr');
         expect(tr.length).toBe(2);
@@ -52,7 +54,7 @@ describe('Localized Simple Select type', function () {
 
     test('Change option value', function () {
         const onchange = jest.fn();
-        const renderedRecordType = renderType(getOptions(), 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType(getOptions(), new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         const tr = renderedRecordType.find('tbody').find('tr');
         const input = tr.find('input');
@@ -74,7 +76,7 @@ describe('Localized Simple Select type', function () {
         // @ts-ignore PHP encodes an empty array instead of object
         options.options[1].values = [];
 
-        const renderedRecordType = renderType(options, 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType(options, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         const tr = renderedRecordType.find('tbody').find('tr');
         const input = tr.find('input');
@@ -92,7 +94,7 @@ describe('Localized Simple Select type', function () {
 
     test('Change option code', function () {
         const onchange = jest.fn();
-        const renderedRecordType = renderType(getOptions(), 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType(getOptions(), new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         const tr = renderedRecordType.find('tbody').find('tr');
         const input = tr.find('input');
@@ -111,7 +113,7 @@ describe('Localized Simple Select type', function () {
     test('Open modal', function () {
         const onchange = jest.fn();
 
-        const renderedRecordType = renderType({} as SelectConfig, 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType({} as SelectConfig, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         const buttons = renderedRecordType.find('button');
         buttons.first().simulate('click');
@@ -124,7 +126,7 @@ describe('Localized Simple Select type', function () {
     test('Close modal', function () {
         const onchange = jest.fn();
 
-        const renderedRecordType = renderType({} as SelectConfig, 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType({} as SelectConfig, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         const buttons = renderedRecordType.find('button');
         buttons.first().simulate('click'); // open modal
@@ -137,7 +139,7 @@ describe('Localized Simple Select type', function () {
 
     test('Remove row', function () {
         const onchange = jest.fn();
-        const renderedRecordType = renderType(getOptions(), 'simple_select_localized', onchange, createLocales());
+        const renderedRecordType = renderType(getOptions(), new LocalizedSelect('simple_select_localized'), onchange, createLocales());
 
         const removeButton = renderedRecordType.find('.AknOptionEditor-remove');
         removeButton.at(0).simulate('click');

--- a/jest/public/reference-entity/attribute/table/type/localized-select.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/localized-select.test.tsx
@@ -11,7 +11,12 @@ describe('Localized Simple Select type', function () {
     test('Default rendering', function () {
         const onchange = jest.fn();
 
-        const renderedRecordType = renderType({} as SelectConfig, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
+        const renderedRecordType = renderType(
+            {} as SelectConfig,
+            new LocalizedSelect('simple_select_localized'),
+            onchange,
+            createLocales()
+        );
 
         expect(onchange.mock.calls.length).toBe(1);
         expect(onchange.mock.calls[0][0]).toStrictEqual({ options: [] });
@@ -113,7 +118,12 @@ describe('Localized Simple Select type', function () {
     test('Open modal', function () {
         const onchange = jest.fn();
 
-        const renderedRecordType = renderType({} as SelectConfig, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
+        const renderedRecordType = renderType(
+            {} as SelectConfig,
+            new LocalizedSelect('simple_select_localized'),
+            onchange,
+            createLocales()
+        );
 
         const buttons = renderedRecordType.find('button');
         buttons.first().simulate('click');
@@ -126,7 +136,12 @@ describe('Localized Simple Select type', function () {
     test('Close modal', function () {
         const onchange = jest.fn();
 
-        const renderedRecordType = renderType({} as SelectConfig, new LocalizedSelect('simple_select_localized'), onchange, createLocales());
+        const renderedRecordType = renderType(
+            {} as SelectConfig,
+            new LocalizedSelect('simple_select_localized'),
+            onchange,
+            createLocales()
+        );
 
         const buttons = renderedRecordType.find('button');
         buttons.first().simulate('click'); // open modal

--- a/jest/public/reference-entity/attribute/table/type/number.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/number.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import renderType from './test-helper';
-import { NumberConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/number';
+import NumberType, { NumberConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/number';
 
 jest.mock('akeneoreferenceentity/tools/translator');
 
 describe('Text type', function () {
     test('Default rendering', function () {
-        const renderedAttributeType = renderType({}, 'number', jest.fn());
+        const renderedAttributeType = renderType({}, new NumberType('number'), jest.fn());
 
         const select = renderedAttributeType.find('select');
         const optionList = select.find('option');
@@ -18,7 +18,7 @@ describe('Text type', function () {
     });
 
     test('Pre-set config', function () {
-        const renderedAttributeType = renderType({ decimal: 'true' }, 'number', jest.fn());
+        const renderedAttributeType = renderType({ decimal: 'true' }, new NumberType('number'), jest.fn());
 
         const select = renderedAttributeType.find('select');
 
@@ -27,7 +27,7 @@ describe('Text type', function () {
 
     test('Change decimal config', function () {
         const onchange = jest.fn();
-        const renderedAttributeType = renderType({}, 'number', onchange);
+        const renderedAttributeType = renderType({}, new NumberType('number'), onchange);
 
         const select = renderedAttributeType.find('select');
 

--- a/jest/public/reference-entity/attribute/table/type/select.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/select.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import renderType from './test-helper';
-import { SelectConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/select';
+import SelectType, { SelectConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/select';
 
 jest.mock('akeneoreferenceentity/tools/translator');
 
 describe('Text type', function () {
     test('Default rendering', function () {
-        const renderedAttributeType = renderType({}, 'simple_select', jest.fn());
+        const renderedAttributeType = renderType({}, new SelectType('simple_select'), jest.fn());
 
         const emptyOptionFields = renderedAttributeType.find('tbody').find('td').find('input');
 
@@ -23,7 +23,7 @@ describe('Text type', function () {
 
     test('Add empty option row on open modal and add them to React state', function () {
         const onchange = jest.fn();
-        const renderedAttributeType = renderType({}, 'simple_select', onchange);
+        const renderedAttributeType = renderType({}, new SelectType('simple_select'), onchange);
 
         const modalButton = renderedAttributeType.find('button').at(0);
         modalButton.simulate('click');
@@ -38,7 +38,7 @@ describe('Text type', function () {
     test('Change value of row 1', function () {
         const onchange = jest.fn();
         const config: SelectConfig = { options: [{ code: 'code', value: 'oldvalue' }] };
-        const renderedAttributeType = renderType(config, 'simple_select', onchange);
+        const renderedAttributeType = renderType(config, new SelectType('simple_select'), onchange);
 
         const firstRowValueField = renderedAttributeType.find('tbody').find('input').at(1);
         firstRowValueField.simulate('change', { target: { value: 'foo' } });
@@ -58,7 +58,7 @@ describe('Text type', function () {
     test('Change code of row 1', function () {
         const onchange = jest.fn();
         const config: SelectConfig = { options: [{ code: 'oldcode', value: 'value' }] };
-        const renderedAttributeType = renderType(config, 'simple_select', onchange);
+        const renderedAttributeType = renderType(config, new SelectType('simple_select'), onchange);
 
         const firstRowValueField = renderedAttributeType.find('tbody').find('input').at(0);
         firstRowValueField.simulate('change', { target: { value: 'code' } });
@@ -93,7 +93,7 @@ describe('Text type', function () {
                 },
             ],
         };
-        const renderedAttributeType = renderType(config, 'simple_select', onchange);
+        const renderedAttributeType = renderType(config, new SelectType('simple_select'), onchange);
 
         const closeButton = renderedAttributeType.find('tbody').find('Close').at(1);
         closeButton.simulate('click');
@@ -134,7 +134,7 @@ describe('Text type', function () {
                 },
             ],
         };
-        const renderedAttributeType = renderType(config, 'simple_select', onchange);
+        const renderedAttributeType = renderType(config, new SelectType('simple_select'), onchange);
 
         const confirmChanges = renderedAttributeType.find('button.ok');
         confirmChanges.simulate('click');

--- a/jest/public/reference-entity/attribute/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/single-reference-entity.test.tsx
@@ -3,8 +3,7 @@ import SingleReferenceEntityType, {
     RefEntityConfig,
 } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/single-reference-entity';
 import * as React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 const userContent = { catalogLocale: 'de_DE', catalogScope: 'ecommerce' };
 jest.mock(

--- a/jest/public/reference-entity/attribute/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/single-reference-entity.test.tsx
@@ -1,0 +1,71 @@
+import renderType, { renderTypeForAsync } from './test-helper';
+import SingleReferenceEntityType, {
+    RefEntityConfig,
+} from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/single-reference-entity';
+import * as React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const userContent = { catalogLocale: 'de_DE', catalogScope: 'ecommerce' };
+jest.mock(
+    'pim/user-context',
+    () => ({
+        get: jest.fn().mockImplementation((key: string) => userContent[key]),
+    }),
+    { virtual: true }
+);
+
+describe('Single Reference Entity type', function () {
+    test('Default rendering', function () {
+        const renderedAttributeType = renderType({}, new SingleReferenceEntityType('single_reference_entity'), jest.fn());
+
+        const select = renderedAttributeType.find('RefEntitySelect').dive().find('select');
+        const options = renderedAttributeType.find('RefEntitySelect').dive().find('options');
+
+        expect(renderedAttributeType.key()).toBe('single_reference_entity0');
+
+        expect(select.length).toBe(1);
+        expect(options.length).toBe(0);
+    });
+
+    test('Rendering with options', async function () {
+        const { container } = renderTypeForAsync({}, new SingleReferenceEntityType('single_reference_entity'), jest.fn());
+
+        const options = await waitFor(() => container.getElementsByTagName('option'));
+
+        expect(options.length).toBe(2);
+
+        expect(options[0].value).toBe('code1');
+        expect(options[0].textContent).toBe('label1');
+
+        expect(options[1].value).toBe('code2');
+        expect(options[1].textContent).toBe('label2');
+    });
+
+    test('Rendering with saved value', async function () {
+        const { container } = renderTypeForAsync(
+            { ref_entity_code: 'code2' },
+            new SingleReferenceEntityType('single_reference_entity'),
+            jest.fn()
+        );
+
+        const select = await waitFor(() => container.getElementsByTagName('select'));
+
+        expect(select[0].value).toBe('code2');
+    });
+
+    test('Change reference entity', async function () {
+        const onchange = jest.fn();
+        const config: RefEntityConfig = { ref_entity_code: 'code2' };
+        const { container } = renderTypeForAsync(config, new SingleReferenceEntityType('single_reference_entity'), onchange);
+
+        const select = await waitFor(() => container.getElementsByTagName('select'));
+        fireEvent.change(select[0], { target: { value: 'code1' } });
+
+        const expectedConfig: RefEntityConfig = { ref_entity_code: 'code1' };
+
+        expect(onchange.mock.calls.length).toBe(1);
+        expect(onchange.mock.calls[0][0]).toStrictEqual(expectedConfig);
+        expect(onchange.mock.calls[0][1]).toBe(0);
+    });
+});

--- a/jest/public/reference-entity/attribute/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/single-reference-entity.test.tsx
@@ -32,13 +32,13 @@ describe('Single Reference Entity type', function () {
 
         const options = await waitFor(() => container.getElementsByTagName('option'));
 
-        expect(options.length).toBe(2);
+        expect(options.length).toBe(3);
 
-        expect(options[0].value).toBe('code1');
-        expect(options[0].textContent).toBe('label1');
+        expect(options[1].value).toBe('code1');
+        expect(options[1].textContent).toBe('label1');
 
-        expect(options[1].value).toBe('code2');
-        expect(options[1].textContent).toBe('label2');
+        expect(options[2].value).toBe('code2');
+        expect(options[2].textContent).toBe('label2');
     });
 
     test('Rendering with saved value', async function () {

--- a/jest/public/reference-entity/attribute/table/type/test-helper.tsx
+++ b/jest/public/reference-entity/attribute/table/type/test-helper.tsx
@@ -4,12 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Type } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/type';
 
-function renderType(
-    config,
-    type: Type,
-    onchange: (config: object, index: number) => void,
-    supportedLocales: Locale[] = []
-) {
+function renderType(config, type: Type, onchange: (config: object, index: number) => void, supportedLocales: Locale[] = []) {
     const configChangeState: ConfigChangeState = {
         typeCode: type.typeCode,
         updateConfig: onchange,

--- a/jest/public/reference-entity/attribute/table/type/test-helper.tsx
+++ b/jest/public/reference-entity/attribute/table/type/test-helper.tsx
@@ -1,4 +1,4 @@
-import { ConfigChangeState, FlagbitTableTypes } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/type';
+import { ConfigChangeState } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/type';
 import Locale from 'akeneoreferenceentity//domain/model/locale';
 import { shallow } from 'enzyme';
 import * as React from 'react';

--- a/jest/public/reference-entity/attribute/table/type/test-helper.tsx
+++ b/jest/public/reference-entity/attribute/table/type/test-helper.tsx
@@ -2,17 +2,23 @@ import { ConfigChangeState, FlagbitTableTypes } from '../../../../../../src/Reso
 import Locale from 'akeneoreferenceentity//domain/model/locale';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { Type } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/type';
 
-function renderType(config, type: string, onchange: (config: object, index: number) => void, supportedLocales: Locale[] = []) {
+function renderType(
+    config,
+    type: Type,
+    onchange: (config: object, index: number) => void,
+    supportedLocales: Locale[] = []
+) {
     const configChangeState: ConfigChangeState = {
-        typeCode: type,
+        typeCode: type.typeCode,
         updateConfig: onchange,
         index: 0,
         config: config,
         supportedLocales: supportedLocales,
     };
 
-    const AttributeType = () => FlagbitTableTypes.typeRegistry.render(configChangeState);
+    const AttributeType = () => type.render(configChangeState);
 
     return shallow(<AttributeType />);
 }

--- a/jest/public/reference-entity/attribute/table/type/test-helper.tsx
+++ b/jest/public/reference-entity/attribute/table/type/test-helper.tsx
@@ -2,6 +2,7 @@ import { ConfigChangeState, FlagbitTableTypes } from '../../../../../../src/Reso
 import Locale from 'akeneoreferenceentity//domain/model/locale';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { render } from '@testing-library/react';
 import { Type } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/type';
 
 function renderType(config, type: Type, onchange: (config: object, index: number) => void, supportedLocales: Locale[] = []) {
@@ -18,4 +19,19 @@ function renderType(config, type: Type, onchange: (config: object, index: number
     return shallow(<AttributeType />);
 }
 
+function asyncRenderType(config, type: Type, onchange: (config: object, index: number) => void, supportedLocales: Locale[] = []) {
+    const configChangeState: ConfigChangeState = {
+        typeCode: type.typeCode,
+        updateConfig: onchange,
+        index: 0,
+        config: config,
+        supportedLocales: supportedLocales,
+    };
+
+    const AttributeType = () => type.render(configChangeState);
+
+    return render(<AttributeType />);
+}
+
 export default renderType;
+export const renderTypeForAsync = asyncRenderType;

--- a/jest/public/reference-entity/attribute/table/type/text.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/text.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import renderType from './test-helper';
+import TextType from "../../../../../../src/Resources/public/reference-entity/attribute/table/type/text";
 
 jest.mock('akeneoreferenceentity/tools/translator');
 
 describe('Text type', function () {
     test('Default rendering', function () {
-        const renderedAttributeType = renderType({}, 'text', jest.fn());
+        const renderedAttributeType = renderType({}, new TextType('text'), jest.fn());
 
         expect(renderedAttributeType.key()).toBe('text0');
         expect(renderedAttributeType.text()).toBe('');

--- a/jest/public/reference-entity/attribute/table/type/text.test.tsx
+++ b/jest/public/reference-entity/attribute/table/type/text.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import renderType from './test-helper';
-import TextType from "../../../../../../src/Resources/public/reference-entity/attribute/table/type/text";
+import TextType from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/text';
 
 jest.mock('akeneoreferenceentity/tools/translator');
 

--- a/jest/public/reference-entity/attribute/table/type/type-registry.test.ts
+++ b/jest/public/reference-entity/attribute/table/type/type-registry.test.ts
@@ -11,7 +11,13 @@ describe('TypeRegistry', function () {
     });
 
     test('getSelectValues()', function () {
-        const expected = [{ code: 'text' }, { code: 'number' }, { code: 'simple_select' }, { code: 'simple_select_localized' }];
+        const expected = [
+            { code: 'text' },
+            { code: 'number' },
+            { code: 'simple_select' },
+            { code: 'simple_select_localized' },
+            { code: 'single_reference_entity' },
+        ];
 
         expect(FlagbitTableTypes.typeRegistry.getSelectValues()).toStrictEqual(expected);
     });

--- a/jest/public/reference-entity/record/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/record.ts
+++ b/jest/public/reference-entity/record/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/record.ts
@@ -1,0 +1,14 @@
+import { Query, SearchResult } from 'akeneoreferenceentity/domain/fetcher/fetcher';
+import { NormalizedItemRecord } from 'akeneoreferenceentity/domain/model/record/record';
+
+class Foo {
+    async search(query: Query): Promise<SearchResult<NormalizedItemRecord>> {
+        return {
+            items: [],
+            matchesCount: 0,
+            totalCount: 0,
+        };
+    }
+}
+
+export default new Foo();

--- a/jest/public/reference-entity/record/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/record.ts
+++ b/jest/public/reference-entity/record/table/type/__mocks__/akeneoreferenceentity/infrastructure/fetcher/record.ts
@@ -1,14 +1,46 @@
 import { Query, SearchResult } from 'akeneoreferenceentity/domain/fetcher/fetcher';
 import { NormalizedItemRecord } from 'akeneoreferenceentity/domain/model/record/record';
 
-class Foo {
+const completeness = { complete: 0, required: 0 };
+
+const items: NormalizedItemRecord[] = [
+    {
+        code: 'foo',
+        completeness: completeness,
+        identifier: 'foo2',
+        image: null,
+        reference_entity_identifier: '',
+        values: [],
+        labels: { de_DE: 'A', en_US: 'A1' },
+    },
+    {
+        code: 'bar',
+        completeness: completeness,
+        identifier: 'bar2',
+        image: null,
+        reference_entity_identifier: '',
+        values: [],
+        labels: { de_DE: 'B', en_US: 'B1' },
+    },
+    {
+        code: 'baz',
+        completeness: completeness,
+        identifier: 'baz2',
+        image: null,
+        reference_entity_identifier: '',
+        values: [],
+        labels: { de_DE: 'C', en_US: 'C1' },
+    },
+];
+
+class Fetcher {
     async search(query: Query): Promise<SearchResult<NormalizedItemRecord>> {
         return {
-            items: [],
-            matchesCount: 0,
-            totalCount: 0,
+            items: items,
+            matchesCount: items.length,
+            totalCount: items.length,
         };
     }
 }
 
-export default new Foo();
+export default new Fetcher();

--- a/jest/public/reference-entity/record/table/type/localized-select.test.tsx
+++ b/jest/public/reference-entity/record/table/type/localized-select.test.tsx
@@ -1,4 +1,5 @@
-import { RecordChangeState, FlagbitTableRecordTypes } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
+import LocalizedSelect from '../../../../../../src/Resources/public/reference-entity/record/table/type/localized-select';
+import { RecordChangeState } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
 import { SelectConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/localized-select';
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 import * as React from 'react';
@@ -78,7 +79,7 @@ describe('Localized Simple Select type', function () {
 
 function renderType(rowData, onchange: (code: string, value: any, index: number) => void, config = { options: [] }) {
     const RecordType = () =>
-        FlagbitTableRecordTypes.typeRegistry.render(createRecordChangeState(rowData, onchange, config as SelectConfig));
+        new LocalizedSelect('simple_select_localized').render(createRecordChangeState(rowData, onchange, config as SelectConfig));
 
     return shallow(<RecordType />);
 }

--- a/jest/public/reference-entity/record/table/type/number.test.tsx
+++ b/jest/public/reference-entity/record/table/type/number.test.tsx
@@ -1,4 +1,5 @@
-import { RecordChangeState, FlagbitTableRecordTypes } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
+import NumberType from '../../../../../../src/Resources/public/reference-entity/record/table/type/number';
+import { RecordChangeState } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
 import { NumberConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/number';
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 import * as React from 'react';
@@ -48,8 +49,7 @@ describe('Number type', function () {
 });
 
 function renderType(rowData, onchange: (code: string, value: any, index: number) => void, config = {}) {
-    const RecordType = () =>
-        FlagbitTableRecordTypes.typeRegistry.render(createRecordChangeState(rowData, onchange, config as NumberConfig));
+    const RecordType = () => new NumberType('number').render(createRecordChangeState(rowData, onchange, config as NumberConfig));
 
     return shallow(<RecordType />);
 }

--- a/jest/public/reference-entity/record/table/type/select.test.tsx
+++ b/jest/public/reference-entity/record/table/type/select.test.tsx
@@ -1,4 +1,5 @@
-import { RecordChangeState, FlagbitTableRecordTypes } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
+import SelectType from '../../../../../../src/Resources/public/reference-entity/record/table/type/select';
+import { RecordChangeState } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
 import { SelectConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/select';
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 import * as React from 'react';
@@ -63,8 +64,7 @@ describe('Simple Select type', function () {
 });
 
 function renderType(rowData, onchange: (code: string, value: any, index: number) => void, config = { options: [] }) {
-    const RecordType = () =>
-        FlagbitTableRecordTypes.typeRegistry.render(createRecordChangeState(rowData, onchange, config as SelectConfig));
+    const RecordType = () => new SelectType('selection').render(createRecordChangeState(rowData, onchange, config as SelectConfig));
 
     return shallow(<RecordType />);
 }

--- a/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
@@ -1,0 +1,101 @@
+import SingleReferenceEntityType from '../../../../../../src/Resources/public/reference-entity/record/table/type/single-reference-entity';
+import { RecordChangeState } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
+import { RefEntityConfig } from '../../../../../../src/Resources/public/reference-entity/attribute/table/type/single-reference-entity';
+import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
+import * as React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const userContent = { catalogLocale: 'de_DE', catalogScope: 'ecommerce' };
+jest.mock(
+    'pim/user-context',
+    () => ({
+        get: jest.fn().mockImplementation((key: string) => userContent[key]),
+    }),
+    { virtual: true }
+);
+
+describe('Single Reference Entity type', function () {
+    test('Default rendering', function () {
+        const { container } = renderType({}, jest.fn());
+
+        const select = container.getElementsByTagName('select');
+        const options = container.getElementsByTagName('option');
+
+        expect(select.length).toBe(1);
+        expect(options.length).toBe(0);
+        expect(select.item(0).value).toBe('');
+    });
+
+    test('Rendering with options', async function () {
+        const { container } = renderType({ selection: 'foo' }, jest.fn());
+
+        const optionList = await waitFor(() => container.getElementsByTagName('option'));
+
+        expect(optionList.length).toBe(3);
+
+        expect(optionList[0].value).toBe('foo');
+        expect(optionList[0].textContent).toBe('A');
+
+        expect(optionList[1].value).toBe('bar');
+        expect(optionList[1].textContent).toBe('B');
+
+        expect(optionList[2].value).toBe('baz');
+        expect(optionList[2].textContent).toBe('C');
+    });
+
+    test('Rendering with saved value', async function () {
+        const { container } = renderType({ selection: 'foo' }, jest.fn());
+
+        const select = await waitFor(() => container.getElementsByTagName('select'));
+
+        expect(select[0].value).toBe('foo');
+    });
+
+    test('onChange event', async function () {
+        const onchange = jest.fn();
+        const { container } = renderType({ code: 'test' }, onchange);
+
+        const select = await waitFor(() => container.getElementsByTagName('select'));
+
+        fireEvent.change(select[0], { target: { value: 'foo' } });
+
+        expect(onchange.mock.calls.length).toBe(1);
+        expect(onchange.mock.calls[0][0]).toBe('selection');
+        expect(onchange.mock.calls[0][1]).toBe('foo');
+        expect(onchange.mock.calls[0][2]).toBe(1);
+    });
+});
+
+function renderType(
+    rowData,
+    onchange: (code: string, value: any, index: number) => void,
+    config: RefEntityConfig = { ref_entity_code: '' }
+) {
+    const RecordType = () =>
+        new SingleReferenceEntityType('single_reference_entity').render(
+            createRecordChangeState(rowData, onchange, config as RefEntityConfig)
+        );
+
+    return render(<RecordType />);
+}
+
+function createRecordChangeState(
+    rowData,
+    onchange: (code: string, value: any, index: number) => void,
+    config: RefEntityConfig
+): RecordChangeState {
+    return {
+        tableRow: {
+            code: 'selection',
+            labels: { de_DE: 'DE' },
+            type: 'single_reference_entity',
+            validations: [],
+            config: config,
+        },
+        updateValue: onchange,
+        index: 1,
+        rowData: rowData,
+        locale: LocaleReference.create('de_DE'),
+    };
+}

--- a/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
@@ -4,7 +4,6 @@ import { RefEntityConfig } from '../../../../../../src/Resources/public/referenc
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 import * as React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
 
 const userContent = { catalogLocale: 'de_DE', catalogScope: 'ecommerce' };
 jest.mock(

--- a/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
@@ -31,16 +31,16 @@ describe('Single Reference Entity type', function () {
 
         const optionList = await waitFor(() => container.getElementsByTagName('option'));
 
-        expect(optionList.length).toBe(3);
+        expect(optionList.length).toBe(4);
 
-        expect(optionList[0].value).toBe('foo');
-        expect(optionList[0].textContent).toBe('A');
+        expect(optionList[1].value).toBe('foo');
+        expect(optionList[1].textContent).toBe('A');
 
-        expect(optionList[1].value).toBe('bar');
-        expect(optionList[1].textContent).toBe('B');
+        expect(optionList[2].value).toBe('bar');
+        expect(optionList[2].textContent).toBe('B');
 
-        expect(optionList[2].value).toBe('baz');
-        expect(optionList[2].textContent).toBe('C');
+        expect(optionList[3].value).toBe('baz');
+        expect(optionList[3].textContent).toBe('C');
     });
 
     test('Rendering with saved value', async function () {

--- a/jest/public/reference-entity/record/table/type/text.test.tsx
+++ b/jest/public/reference-entity/record/table/type/text.test.tsx
@@ -1,4 +1,5 @@
-import { RecordChangeState, FlagbitTableRecordTypes } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
+import TextType from '../../../../../../src/Resources/public/reference-entity/record/table/type/text';
+import { RecordChangeState } from '../../../../../../src/Resources/public/reference-entity/record/table/type/type';
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 import * as React from 'react';
 import { shallow } from 'enzyme';
@@ -38,7 +39,7 @@ describe('Text type', function () {
 });
 
 function renderType(rowData, onchange: (code: string, value: any, index: number) => void) {
-    const RecordType = () => FlagbitTableRecordTypes.typeRegistry.render(createRecordChangeState(rowData, onchange));
+    const RecordType = () => new TextType('text').render(createRecordChangeState(rowData, onchange));
 
     return shallow(<RecordType />);
 }

--- a/src/Attribute/JsonSchema/TableAttributeCreationValidator.php
+++ b/src/Attribute/JsonSchema/TableAttributeCreationValidator.php
@@ -77,7 +77,13 @@ final class TableAttributeCreationValidator implements AttributeValidatorInterfa
                             ],
                             'type' => [
                                 'type' => ['string'],
-                                'enum' => ['text', 'number', 'simple_select', 'simple_select_localized'],
+                                'enum' => [
+                                    'text',
+                                    'number',
+                                    'simple_select',
+                                    'simple_select_localized',
+                                    'single_reference_entity'
+                                ],
                             ],
                             'validations' => [
                                 'minItems' => 0,

--- a/src/Attribute/JsonSchema/TableAttributeEditValidator.php
+++ b/src/Attribute/JsonSchema/TableAttributeEditValidator.php
@@ -75,7 +75,13 @@ class TableAttributeEditValidator implements AttributeValidatorInterface
                             ],
                             'type' => [
                                 'type' => ['string'],
-                                'enum' => ['text', 'number', 'simple_select', 'simple_select_localized'],
+                                'enum' => [
+                                    'text',
+                                    'number',
+                                    'simple_select',
+                                    'simple_select_localized',
+                                    'single_reference_entity'
+                                ],
                             ],
                             'validations' => [
                                 'minItems' => 0,

--- a/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
@@ -2,6 +2,7 @@ import { Type, ConfigChangeState } from './type';
 import referenceEntityFetcher from 'akeneoreferenceentity/infrastructure/fetcher/reference-entity';
 import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/reference-entity/list';
 import React from 'react';
+const userContext = require('pim/user-context');
 
 interface RefEntitySelectProp {
     ref_entity_code: string;
@@ -19,7 +20,7 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
             refEntities.map((option) => {
                 options.push({
                     code: option.getIdentifier().stringValue(),
-                    name: option.getIdentifier().stringValue(),
+                    name: option.getLabel(userContext.get('catalogLocale')),
                 });
             });
 

--- a/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
@@ -34,9 +34,10 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
     render() {
         return (
             <select value={this.props.ref_entity_code} onChange={this.props.update_state}>
+                {this.state.options.length !== 0 ? (<option>{''}</option>) : ''}
                 {this.state.options.map((refEntity: { code: string; name: string }, index: number) => {
                     return (
-                        <option key={`test_${refEntity.code}_${index}`} value={refEntity.code}>
+                        <option key={`single_reference_entity_${refEntity.code}_${index}`} value={refEntity.code}>
                             {refEntity.name}
                         </option>
                     );

--- a/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
@@ -2,7 +2,6 @@ import { Type, ConfigChangeState } from './type';
 import referenceEntityFetcher from 'akeneoreferenceentity/infrastructure/fetcher/reference-entity';
 import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/reference-entity/list';
 import React from 'react';
-const userContext = require('pim/user-context');
 
 interface RefEntitySelectProp {
     ref_entity_code: string;
@@ -15,6 +14,8 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
     };
 
     componentDidMount() {
+        const userContext = require('pim/user-context');
+
         referenceEntityFetcher.fetchAll().then((refEntities: ReferenceEntityListItem[]) => {
             const options: { code: string; name: string }[] = [];
             refEntities.map((option) => {

--- a/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/attribute/table/type/single-reference-entity.tsx
@@ -1,0 +1,76 @@
+import { Type, ConfigChangeState } from './type';
+import referenceEntityFetcher from 'akeneoreferenceentity/infrastructure/fetcher/reference-entity';
+import ReferenceEntityListItem from 'akeneoreferenceentity/domain/model/reference-entity/list';
+import React from 'react';
+
+interface RefEntitySelectProp {
+    ref_entity_code: string;
+    update_state: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+class RefEntitySelect extends React.Component<RefEntitySelectProp> {
+    state = {
+        options: [],
+    };
+
+    componentDidMount() {
+        referenceEntityFetcher.fetchAll().then((refEntities: ReferenceEntityListItem[]) => {
+            const options: { code: string; name: string }[] = [];
+            refEntities.map((option) => {
+                options.push({
+                    code: option.getIdentifier().stringValue(),
+                    name: option.getIdentifier().stringValue(),
+                });
+            });
+
+            this.setState({
+                options: options,
+            });
+        });
+    }
+
+    render() {
+        return (
+            <select value={this.props.ref_entity_code} onChange={this.props.update_state}>
+                {this.state.options.map((refEntity: { code: string; name: string }, index: number) => {
+                    return (
+                        <option key={`test_${refEntity.code}_${index}`} value={refEntity.code}>
+                            {refEntity.name}
+                        </option>
+                    );
+                })}
+            </select>
+        );
+    }
+}
+
+export type RefEntityConfig = {
+    ref_entity_code: string;
+};
+
+export default class SingleReferenceEntity implements Type {
+    private readonly default: RefEntityConfig = {
+        ref_entity_code: '',
+    };
+
+    constructor(readonly typeCode: string) {}
+
+    render(changeState: ConfigChangeState) {
+        const key = this.typeCode + changeState.index;
+        // TODO This needs a better type/content check
+        if (Object.keys(changeState.config).length === 0) {
+            changeState.config = this.default;
+            changeState.updateConfig(this.default, changeState.index);
+        }
+        const config = changeState.config as RefEntityConfig;
+
+        const update = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+            config.ref_entity_code = event.target.value;
+            changeState.updateConfig(config, changeState.index);
+        };
+
+        return <React.Fragment key={key}>
+            <RefEntitySelect ref_entity_code={config.ref_entity_code} update_state={update} />
+        </React.Fragment>;
+    }
+}

--- a/src/Resources/public/reference-entity/attribute/table/type/type.ts
+++ b/src/Resources/public/reference-entity/attribute/table/type/type.ts
@@ -2,6 +2,7 @@ import Text from './text';
 import Number from './number';
 import Select from './select';
 import LocalizedSelect from './localized-select';
+import SingleReferenceEntity from './single-reference-entity';
 import Locale from 'akeneoreferenceentity/domain/model/locale';
 
 // Export for custom implementations
@@ -76,5 +77,6 @@ export namespace FlagbitTableTypes {
         new SimpleTypeFactory('number', Number),
         new SimpleTypeFactory('simple_select', Select),
         new SimpleTypeFactory('simple_select_localized', LocalizedSelect),
+        new SimpleTypeFactory('single_reference_entity', SingleReferenceEntity),
     ]);
 }

--- a/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
@@ -2,8 +2,9 @@ import { Type, RecordChangeState } from './type';
 import React from 'react';
 import { RefEntityConfig } from '../../../attribute/table/type/single-reference-entity';
 import recordFetcher from 'akeneoreferenceentity/infrastructure/fetcher/record';
-import { Query } from "akeneoreferenceentity/domain/fetcher/fetcher";
-
+import { Query, SearchResult } from "akeneoreferenceentity/domain/fetcher/fetcher";
+import { NormalizedItemRecord } from 'akeneoreferenceentity/domain/model/record/record';
+const userContext = require('pim/user-context');
 
 interface RefEntitySelectProp {
     ref_entity_code: string;
@@ -24,13 +25,20 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
                 value: this.props.ref_entity_code,
             }
         ];
-        const query: Query = {channel: 'ecommerce', filters: filter, locale: 'en_US', page: 0, size: 1000};
-        recordFetcher.search(query).then((refEntities) => {
+        const query: Query = {
+            channel: userContext.get('catalogScope'),
+            filters: filter,
+            locale: userContext.get('catalogLocale'),
+            page: 0,
+            size: 1000
+        };
+
+        recordFetcher.search(query).then((refEntities: SearchResult<NormalizedItemRecord>) => {
             const options: { code: string; name: string }[] = [];
             refEntities.items.map((option) => {
                 options.push({
                     code: option.code,
-                    name: option.code,
+                    name: option.labels[userContext.get('catalogLocale')] || `[${option.code}]`,
                 });
             });
 

--- a/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
@@ -4,7 +4,6 @@ import { RefEntityConfig } from '../../../attribute/table/type/single-reference-
 import recordFetcher from 'akeneoreferenceentity/infrastructure/fetcher/record';
 import { Query, SearchResult } from "akeneoreferenceentity/domain/fetcher/fetcher";
 import { NormalizedItemRecord } from 'akeneoreferenceentity/domain/model/record/record';
-const userContext = require('pim/user-context');
 
 interface RefEntitySelectProp {
     ref_entity_code: string;
@@ -18,6 +17,8 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
     };
 
     componentDidMount() {
+        const userContext = require('pim/user-context');
+
         const filter = [
             {
                 field: 'reference_entity',
@@ -35,7 +36,7 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
 
         recordFetcher.search(query).then((refEntities: SearchResult<NormalizedItemRecord>) => {
             const options: { code: string; name: string }[] = [];
-            refEntities.items.map((option) => {
+            refEntities.items.map((option: NormalizedItemRecord) => {
                 options.push({
                     code: option.code,
                     name: option.labels[userContext.get('catalogLocale')] || `[${option.code}]`,

--- a/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
@@ -46,12 +46,17 @@ class RefEntitySelect extends React.Component<RefEntitySelectProp> {
             this.setState({
                 options: options,
             });
+        }).catch(() => {
+            this.setState({
+                options: [],
+            });
         });
     }
 
     render() {
         return (
             <select value={this.props.record} onChange={this.props.update_state}>
+                {this.state.options.length !== 0 ? (<option>{''}</option>) : ''}
                 {this.state.options.map((refEntity: { code: string; name: string }, index: number) => {
                     return (
                         <option key={`test_${refEntity.code}_${index}`} value={refEntity.code}>

--- a/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
@@ -1,0 +1,77 @@
+import { Type, RecordChangeState } from './type';
+import React from 'react';
+import { RefEntityConfig } from '../../../attribute/table/type/single-reference-entity';
+import recordFetcher from 'akeneoreferenceentity/infrastructure/fetcher/record';
+import { Query } from "akeneoreferenceentity/domain/fetcher/fetcher";
+
+
+interface RefEntitySelectProp {
+    ref_entity_code: string;
+    update_state: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+    record: string;
+}
+
+class RefEntitySelect extends React.Component<RefEntitySelectProp> {
+    state = {
+        options: [],
+    };
+
+    componentDidMount() {
+        const filter = [
+            {
+                field: 'reference_entity',
+                operator: '=',
+                value: this.props.ref_entity_code,
+            }
+        ];
+        const query: Query = {channel: 'ecommerce', filters: filter, locale: 'en_US', page: 0, size: 1000};
+        recordFetcher.search(query).then((refEntities) => {
+            const options: { code: string; name: string }[] = [];
+            refEntities.items.map((option) => {
+                options.push({
+                    code: option.code,
+                    name: option.code,
+                });
+            });
+
+            this.setState({
+                options: options,
+            });
+        });
+    }
+
+    render() {
+        return (
+            <select value={this.props.record} onChange={this.props.update_state}>
+                {this.state.options.map((refEntity: { code: string; name: string }, index: number) => {
+                    return (
+                        <option key={`test_${refEntity.code}_${index}`} value={refEntity.code}>
+                            {refEntity.name}
+                        </option>
+                    );
+                })}
+            </select>
+        );
+    }
+}
+
+export default class SingleReferenceEntity implements Type {
+    constructor(readonly typeCode: string) {}
+
+    render(recordRowData: RecordChangeState) {
+        const config: RefEntityConfig = recordRowData.tableRow.config as RefEntityConfig;
+
+        const update = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+            recordRowData.updateValue(recordRowData.tableRow.code, event.currentTarget.value, recordRowData.index);
+        };
+
+        return (
+            <React.Fragment key={this.typeCode + recordRowData.index}>
+                <RefEntitySelect ref_entity_code={config.ref_entity_code}
+                                 update_state={update}
+                                 record={recordRowData.rowData[recordRowData.tableRow.code] || ''}
+                />
+            </React.Fragment>
+        );
+    }
+}

--- a/src/Resources/public/reference-entity/record/table/type/type.ts
+++ b/src/Resources/public/reference-entity/record/table/type/type.ts
@@ -3,6 +3,7 @@ import Text from './text';
 import Number from './number';
 import Select from './select';
 import LocalizedSelect from './localized-select';
+import SingleReferenceEntity from './single-reference-entity';
 import { TableDataRow } from '../table';
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 
@@ -68,5 +69,6 @@ export namespace FlagbitTableRecordTypes {
         new SimpleTypeFactory('number', Number),
         new SimpleTypeFactory('simple_select', Select),
         new SimpleTypeFactory('simple_select_localized', LocalizedSelect),
+        new SimpleTypeFactory('single_reference_entity', SingleReferenceEntity),
     ]);
 }

--- a/src/Resources/translations/jsmessages.de.xlf
+++ b/src/Resources/translations/jsmessages.de.xlf
@@ -62,6 +62,11 @@
                 <target>Einfachauswahl (mehrsprachig)</target>
             </trans-unit>
 
+            <trans-unit id="flagbit_reference_entity_table_attribute_column_type_single_reference_entity">
+                <source>flagbit_reference_entity_table.attribute.column_type.single_reference_entity</source>
+                <target>Einfachauswahl Reference Entity</target>
+            </trans-unit>
+
             <trans-unit id="flagbit_reference_entity_table_attribute_column_type_number_label_decimal">
                 <source>flagbit_reference_entity_table.attribute.column_type.number.label.decimal</source>
                 <target>Dezimal</target>

--- a/src/Resources/translations/jsmessages.en.xlf
+++ b/src/Resources/translations/jsmessages.en.xlf
@@ -62,6 +62,11 @@
                 <target>Simple Select (multilanguage)</target>
             </trans-unit>
 
+            <trans-unit id="flagbit_reference_entity_table_attribute_column_type_single_reference_entity">
+                <source>flagbit_reference_entity_table.attribute.column_type.single_reference_entity</source>
+                <target>Single Reference Entity</target>
+            </trans-unit>
+
             <trans-unit id="flagbit_reference_entity_table_attribute_column_type_number_label_decimal">
                 <source>flagbit_reference_entity_table.attribute.column_type.number.label.decimal</source>
                 <target>Decimal</target>


### PR DESCRIPTION
The single_reference_entity allows to select a Reference Entity in the config and its Records for that column type in a Record.