### PR TITLE
Add placeholder-option for select fields

### DIFF
--- a/jest/public/reference-entity/record/table/type/localized-select.test.tsx
+++ b/jest/public/reference-entity/record/table/type/localized-select.test.tsx
@@ -28,16 +28,16 @@ describe('Localized Simple Select type', function () {
 
         const optionList = renderedRecordType.find('select').find('option');
 
-        expect(optionList.length).toBe(3);
+        expect(optionList.length).toBe(4);
 
-        expect(optionList.at(0).props().value).toBe('foo');
-        expect(optionList.at(0).text()).toBe('Das A');
+        expect(optionList.at(1).props().value).toBe('foo');
+        expect(optionList.at(1).text()).toBe('Das A');
 
-        expect(optionList.at(1).props().value).toBe('bar');
-        expect(optionList.at(1).text()).toBe('Das B');
+        expect(optionList.at(2).props().value).toBe('bar');
+        expect(optionList.at(2).text()).toBe('Das B');
 
-        expect(optionList.at(2).props().value).toBe('baz');
-        expect(optionList.at(2).text()).toBe('Das C');
+        expect(optionList.at(3).props().value).toBe('baz');
+        expect(optionList.at(3).text()).toBe('Das C');
     });
 
     test('Show code in option if no value is given', function () {
@@ -48,10 +48,10 @@ describe('Localized Simple Select type', function () {
 
         const optionList = renderedRecordType.find('select').find('option');
 
-        expect(optionList.length).toBe(1);
+        expect(optionList.length).toBe(2);
 
-        expect(optionList.at(0).props().value).toBe('foo');
-        expect(optionList.at(0).text()).toBe('[foo]');
+        expect(optionList.at(1).props().value).toBe('foo');
+        expect(optionList.at(1).text()).toBe('[foo]');
     });
 
     test('Rendering with saved value', function () {

--- a/jest/public/reference-entity/record/table/type/select.test.tsx
+++ b/jest/public/reference-entity/record/table/type/select.test.tsx
@@ -28,16 +28,16 @@ describe('Simple Select type', function () {
 
         const optionList = renderedRecordType.find('select').find('option');
 
-        expect(optionList.length).toBe(3);
+        expect(optionList.length).toBe(4);
 
-        expect(optionList.at(0).props().value).toBe('foo');
-        expect(optionList.at(0).text()).toBe('A');
+        expect(optionList.at(1).props().value).toBe('foo');
+        expect(optionList.at(1).text()).toBe('A');
 
-        expect(optionList.at(1).props().value).toBe('bar');
-        expect(optionList.at(1).text()).toBe('B');
+        expect(optionList.at(2).props().value).toBe('bar');
+        expect(optionList.at(2).text()).toBe('B');
 
-        expect(optionList.at(2).props().value).toBe('baz');
-        expect(optionList.at(2).text()).toBe('C');
+        expect(optionList.at(3).props().value).toBe('baz');
+        expect(optionList.at(3).text()).toBe('C');
     });
 
     test('Rendering with saved value', function () {

--- a/src/Resources/public/reference-entity/record/table/type/localized-select.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/localized-select.tsx
@@ -16,6 +16,7 @@ export default class LocalizedSelect implements Type {
                     }}
                     value={recordRowData.rowData[recordRowData.tableRow.code] || ''}
                 >
+                    {config.options.length !== 0 ? (<option>{''}</option>) : ''}
                     {config.options.map((option, index: number) => {
                         let value: string = option.code.length === 0 ? '' : '[' + option.code + ']';
                         const locale: string = recordRowData.locale.stringValue();

--- a/src/Resources/public/reference-entity/record/table/type/select.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/select.tsx
@@ -16,6 +16,7 @@ export default class Select implements Type {
                     }}
                     value={recordRowData.rowData[recordRowData.tableRow.code] || ''}
                 >
+                    {config.options.length !== 0 ? (<option>{''}</option>) : ''}
                     {config.options.map((option, index: number) => {
                         return (
                             <option key={`select${recordRowData.index}_${index}`} value={option.code}>


### PR DESCRIPTION
This prevents that the first option, which is neither pre-selected nor
changing the state when selected, will become a default placeholder. The user
will be forced to select an option if the user is intended to.