### PR TITLE
Fix of the select2 display after drag and drop

### DIFF
--- a/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
+++ b/jest/public/reference-entity/record/table/type/single-reference-entity.test.tsx
@@ -4,6 +4,7 @@ import { RefEntityConfig } from '../../../../../../src/Resources/public/referenc
 import LocaleReference from 'akeneoreferenceentity/domain/model/locale-reference';
 import * as React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import $ from 'jquery';
 
 const userContent = { catalogLocale: 'de_DE', catalogScope: 'ecommerce' };
 jest.mock(
@@ -51,6 +52,16 @@ describe('Single Reference Entity type', function () {
         expect(onchange.mock.calls[0][0]).toBe('selection');
         expect(onchange.mock.calls[0][1]).toBe('foo');
         expect(onchange.mock.calls[0][2]).toBe(1);
+    });
+
+    test('onChange event sets label value', async function () {
+        const { container } = renderType({ code: 'test' }, jest.fn());
+
+        const input = await waitFor(() => container.querySelector('#mycode_1_select'));
+
+        fireEvent.change(input, { target: { value: 'foo' } });
+
+        expect(container.textContent.trim()).toBe('A');
     });
 });
 

--- a/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
+++ b/src/Resources/public/reference-entity/record/table/type/single-reference-entity.tsx
@@ -16,6 +16,10 @@ interface RefEntitySelectProp {
 class RefEntitySelect extends React.Component<RefEntitySelectProp> {
     rendered = false;
 
+    componentDidUpdate() {
+        $(`#${this.props.id}`).trigger('change.select2');
+    }
+
     componentDidMount() {
         const userContext = require('pim/user-context');
 
@@ -75,7 +79,7 @@ export default class SingleReferenceEntity implements Type {
         };
 
         return (
-            <React.Fragment key={this.typeCode + recordRowData.index}>
+            <React.Fragment key={this.typeCode + config.ref_entity_code + recordRowData.index}>
                 <RefEntitySelect ref_entity_code={config.ref_entity_code}
                                  update_state={update}
                                  record={recordRowData.rowData[recordRowData.tableRow.code] || ''}


### PR DESCRIPTION
Drag and Drop of record rows where one column is a Single Reference Entity type didn't update the display of the value. While the values are set correct, the name in the Select2 element doesn't update. This is a fix for this issue.