### PR TITLE
Add cronjob for monthly test run

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,8 +1,10 @@
 name: "Backend Tests"
 
 on:
-  - "push"
-  - "pull_request"
+  push: ~
+  pull_request: ~
+  schedule:
+    - cron: "0 0 1 * *"
 
 jobs:
   backend:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,8 +1,10 @@
 name: "Frontend Tests"
 
 on:
-  - "push"
-  - "pull_request"
+  push: ~
+  pull_request: ~
+  schedule:
+    - cron: "0 0 1 * *"
 
 jobs:
   frontend:


### PR DESCRIPTION
The cronjob is supposed to check regulary on newer PIM versions
for compatibility during bigger development hiatus.